### PR TITLE
Improve reliability, especially at low clock speed

### DIFF
--- a/DHT.h
+++ b/DHT.h
@@ -24,6 +24,13 @@
    2013-06-10: Initial version
    2013-06-12: Refactored code
    2013-07-01: Add a resetTimer method
+   2015-04-25: Remove resetTimer(). Require readSensor() to be called before
+               getTemperature()/getHumidity() and remove the sampling rate
+               check, so that we don't need to rely on millis() being accurate.
+               This means that we can support sleep mode. Improve reliability
+               on 8MHz devices by disabling interrupts and using pulseIn()
+               instead of our own busy loop.
+
  ******************************************************************/
 
 #ifndef dht_h
@@ -56,10 +63,16 @@ public:
   DHT_ERROR_t;
 
   void setup(uint8_t pin, DHT_MODEL_t model=AUTO_DETECT);
-  void resetTimer();
 
-  float getTemperature();
-  float getHumidity();
+  void readSensor();
+
+  float getTemperature() {
+    return temperature;
+  }
+
+  float getHumidity() {
+    return humidity;
+  }
 
   DHT_ERROR_t getStatus() { return error; };
   const char* getStatusString();
@@ -80,8 +93,6 @@ public:
   static float toCelsius(float fromFahrenheit) { return (fromFahrenheit - 32.0) / 1.8; };
 
 protected:
-  void readSensor();
-
   float temperature;
   float humidity;
 
@@ -90,7 +101,6 @@ protected:
 private:
   DHT_MODEL_t model;
   DHT_ERROR_t error;
-  unsigned long lastReadTime;
 };
 
 #endif /*dht_h*/

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ void loop()
 {
   delay(dht.getMinimumSamplingPeriod());
 
+  dht.readSensor();
   Serial.print(dht.getHumidity());
   Serial.print("\t");
   Serial.print(dht.getTemperature());


### PR DESCRIPTION
I found that the library was not working reliably with my 8 MHz Seeeduino Stalker. Some investigation with an oscilloscope showed that the input polling loop was quite slow (maybe 8us), and timer interrupts were taking ~10us. This meant that the polling loop commonly missed the first sensor-driven transition after pullup, and any transitions which occur close to timer interrupts. So:

* Use pulseIn() instead of our own loop. This is a little bit faster
  than what was done before, is calibrated correctly, and could
  potentially be optimised upstream to provide better resolution in
  future. It makes the code a bit simpler and avoids the need to watch
  for the first sensor pulldown.
* Disable interrupts during pulseIn(), to provide accurate timing.
* Disabling interrupts, and the fact that I was using sleep mode,
  meant that millis() was not accurate. So instead of depending on
  millis() to determine whether to do a sensor read, require the caller
  to explicitly trigger a sensor read, and rely on the caller to wait
  the requisite sampling period. This means removing resetTimer() and
  making readSensor() public.

Also:
* Use INPUT_PULLUP, which was introduced in Arduino 1.0.1.

Tested on DHT11 and RHT03 (like DHT22) in autodetect mode. Gathered data from the RHT03 for 6 days, 1800 samples, with no timeout or checksum errors.