### PR TITLE
Explicit datatype, required fix for DHT22 on STM32 combinason (at least)

### DIFF
--- a/DHT.cpp
+++ b/DHT.cpp
@@ -142,9 +142,9 @@ void DHT::readSensor()
   // - Then 40 bits: RISING and then a FALLING edge per bit
   // To keep our code simple, we accept any HIGH or LOW reading if it's max 85 usecs long
 
-  word rawHumidity;
-  word rawTemperature;
-  word data;
+  uint16_t rawHumidity;
+  uint16_t rawTemperature;
+  uint16_t data;
 
   for ( int8_t i = -3 ; i < 2 * 40; i++ ) {
     byte age;


### PR DESCRIPTION
Hi !

Thanks for your nice and reliable lib ! I use it on AVR and ported my project to STM32F103C8T6 (aka bluepill).

I had to use explicit datatype, as "word" is 16-bit unsigned i declare it as uint16_t in this change, and this fixed humidity readings on my stm32duino sketch.

As a double-check i compared the compiled binaries before and after this change on AVR, and it doesn't change one single bit of the produced code.

So please include it, as it would allow me to remove my own "fork"..

Regards,
Olivier
