### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -19,8 +19,8 @@ getStatus	KEYWORD2
 getStatusString	KEYWORD2
 getModel	KEYWORD2
 getMinimumSamplingPeriod	KEYWORD2
-toFahrenheit  KEYWORD2
-toCelsius  KEYWORD2
+toFahrenheit	KEYWORD2
+toCelsius	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords